### PR TITLE
Enable support for using Chromium's Kiosk mode

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,6 +1,7 @@
 ---
 url: 'http://152.78.162.68:8080'
 hostname: raspberrypi.local
+browser_type: firefox
 
 timezone: Europe/London
 

--- a/hieradata/node/b8:27:eb:65:17:d1.yaml
+++ b/hieradata/node/b8:27:eb:65:17:d1.yaml
@@ -2,3 +2,4 @@
 ---
 url: https://www.youtube-nocookie.com/embed/cPk0i3ndPmA
 hostname: pi-livestream-sb4.srobo
+browser_type: chromium-browser

--- a/modules/srcomp_kiosk/manifests/init.pp
+++ b/modules/srcomp_kiosk/manifests/init.pp
@@ -8,6 +8,7 @@ class srcomp_kiosk {
   $user_config  = "${user_home}/.config"
   $user_ssh     = "${user_home}/.ssh"
   $url          = hiera('url')
+  $browser_type = hiera('browser_type')
   $timezone     = hiera('timezone')
 
   $compbox_ip   = hiera('compbox_ip')
@@ -113,7 +114,7 @@ class srcomp_kiosk {
   }
 
   $kiosk_script = "${opt_kioskdir}/kiosk.py"
-  $start_command = $kiosk_script
+  $start_command = "$kiosk_script --browser-type ${browser_type}"
   $log_dir = $kiosk_logdir
   file { $kiosk_runner:
     ensure  => file,

--- a/modules/srcomp_kiosk/manifests/init.pp
+++ b/modules/srcomp_kiosk/manifests/init.pp
@@ -29,6 +29,7 @@ class srcomp_kiosk {
             ,"python3-yaml"
             ,"x11-xserver-utils"
             ,"screen"
+            ,"xdotool"
             ]:
     ensure => installed,
   }


### PR DESCRIPTION
This introduces the idea of browser types (separate from the browser path) and allows using Chromium's kiosk mode in place of Firefox.