### PR TITLE
Configure a reverse SSH tunnel from the public compbox

### DIFF
--- a/modules/srcomp_kiosk/manifests/init.pp
+++ b/modules/srcomp_kiosk/manifests/init.pp
@@ -15,6 +15,7 @@ class srcomp_kiosk {
   $compbox_hostname = hiera('compbox_hostname')
 
   include 'srcomp_kiosk::hostname'
+  include 'srcomp_kiosk::tunnel'
 
   class { '::ntp':
     servers => [$compbox_hostname],

--- a/modules/srcomp_kiosk/manifests/systemd_service.pp
+++ b/modules/srcomp_kiosk/manifests/systemd_service.pp
@@ -1,0 +1,41 @@
+define srcomp_kiosk::systemd_service (
+  $command,
+  $user,
+  $desc,
+  $dir = undef,
+  $memory_limit = undef,
+  $depends = ['network.target'],
+  $environment = undef,
+  $subs = []
+) {
+  $service_name = "${title}.service"
+  $service_file = "/etc/systemd/system/${service_name}"
+
+  $service_description = $desc
+  $start_dir = $dir
+  $start_command = $command
+  $depends_str = join($depends, ' ')
+
+  file { $service_file:
+    ensure  => present,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('srcomp_kiosk/systemd_service.erb'),
+  } ->
+  file { "/etc/systemd/system/multi-user.target.wants/${service_name}":
+    ensure  => link,
+    target  => $service_file,
+  } ->
+  exec { "${title}-systemd-load":
+    provider  => 'shell',
+    command   => 'systemctl daemon-reload',
+    onlyif    => "systemctl --all | grep -F ${service_name}; if test $? = 0; then exit 1; fi; exit 0",
+    subscribe => File[$service_file],
+  } ->
+  service { $title:
+    ensure    => running,
+    enable    => true,
+    subscribe => union([File[$service_file]], $subs),
+  }
+}

--- a/modules/srcomp_kiosk/manifests/tunnel.pp
+++ b/modules/srcomp_kiosk/manifests/tunnel.pp
@@ -1,0 +1,45 @@
+class srcomp_kiosk::tunnel ( $remote_ssh_port = lookup('remote_ssh_port') ) {
+  package { 'autossh':
+    ensure => installed,
+  }
+
+  $home_dir = '/home/autossh'
+  $ssh_dir = "${home_dir}/.ssh"
+  $key_file = "${ssh_dir}/id_ed25519"
+
+  $tunnel_host = 'srcomp.studentrobotics.org'
+
+  user { 'autossh':
+    ensure      => present,
+    comment     => 'A user for port forwarding',
+    gid         => 'users',
+    managehome  => true,
+    shell       => '/usr/sbin/nologin',
+  } ->
+  file { $ssh_dir:
+    ensure  => directory,
+    owner   => 'autossh',
+    group   => 'users',
+    mode    => '0700',
+  } ->
+  exec { "ssh-keyscan ${tunnel_host} for tunnel user":
+    command => "/usr/bin/ssh-keyscan ${tunnel_host} > ${ssh_dir}/known_hosts",
+    cwd     => $home_dir,
+    user    => 'autossh',
+    creates => "${ssh_dir}/known_hosts",
+  } ->
+  exec { 'Create ssh key for tunnel user':
+    command => "/usr/bin/ssh-keygen -t ed25519 -f ${key_file}",
+    cwd     => $home_dir,
+    user    => 'autossh',
+    creates => $key_file,
+  } ->
+  srcomp_kiosk::systemd_service { 'autossh-tunnel':
+    desc        => 'AutoSSH tunneling SSH access to the public compbox.',
+    user        => 'autossh',
+    command     => "/usr/bin/autossh -M 0 -o 'ServerAliveInterval 30' -o 'ExitOnForwardFailure yes' -N -R ${remote_ssh_port}:localhost:22 -i ${key_file} autossh@${tunnel_host}",
+    environment => 'AUTOSSH_GATETIME=0',
+    require     => Package['autossh'],
+    subs        => [Exec['Create ssh key for tunnel user']],
+  }
+}

--- a/modules/srcomp_kiosk/templates/systemd_service.erb
+++ b/modules/srcomp_kiosk/templates/systemd_service.erb
@@ -1,0 +1,24 @@
+[Unit]
+Description=<%= @service_description %>
+After=<%= @depends_str %>
+
+[Service]
+User=<%= @user %>
+
+Type=simple
+Restart=on-failure
+<% if @environment %>
+Environment=<%= @environment %>
+<% end %>
+<% if @memory_limit %>
+MemoryLimit=<%= @memory_limit %>
+<% end %>
+
+<% if @start_dir %>
+WorkingDirectory=<%= @start_dir %>
+<% end %>
+
+ExecStart=<%= @start_command %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This provides a way to remotely administer the kiosk devices without needing them to be on the same network.

Based on guidance at https://www.everythingcli.org/ssh-tunnelling-for-fun-and-profit-autossh/

TODO:
- assign ports to each Pi (ideally based on something in the pi_macs file)
- apply to all pis
- add generated ssh keys to https://github.com/PeterJCLaw/srcomp-puppet/blob/master/modules/compbox/files/autossh-authorized_keys
